### PR TITLE
Add Initial Python Notebook

### DIFF
--- a/starter_notebook.ipynb
+++ b/starter_notebook.ipynb
@@ -1,0 +1,42 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Cuaderno Inicial de Python\n",
+    "\n",
+    "Este cuaderno contiene ejemplos básicos para empezar a trabajar."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Hola, mundo!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Continúa agregando tus propias celdas de código y notas aquí."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": ""
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR introduces a new Python notebook named `starter_notebook.ipynb`. The notebook includes markdown and code cells to provide a basic structure for users to begin their coding journey with Python. It contains:
- A markdown cell with a title and introductory text.
- A simple code cell that prints 'Hola, mundo!'.
- Guidance for users to add their own code and notes.

This will serve as a helpful starting point for beginners.

---

> This pull request was co-created with Cosine Genie

Original Task: [GENIE/mnj041dek83r](https://cosine.sh/ue/GENIE/task/mnj041dek83r)
Author: Gianfranco Tomaino
